### PR TITLE
[Triton] Enable swizzling for NT operands (k is the leading dim)

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -98,21 +98,7 @@ A_{3, 2}  A_{3, 3}  A_{3, 0}  A_{3, 1} ...   [phase 1] /
           if (order[0] == inner)
             return $_get(context, 1, 1, 1, order);
 
-          // Get k_base based on the element type
-          // For now, the k_base rules are as follows
-          // 1. All selected mfma instructions produce a single block
-          // 2. For f16 data type, 2 VGPRs are used for operand A --> k_base = 4
-          // 3. For non-f16 data types, 1 VGPR are used for operand A
-          //    k_base = 32 / elemTypeInBits
-          // 4. TODO: what about f64?
-          // TODO: For more general mfma instruction selection logic, it could
-          // be difficult to infer k_base based on eleTy only.
-          // Then it's better to embed k_base into MfmaEncodingAttr
-          unsigned k_base;
-          if (eltTy.isF16())
-            k_base = 2 * 32 / eltTy.getIntOrFloatBitWidth();
-          else
-            k_base = 32 / eltTy.getIntOrFloatBitWidth();
+          unsigned k_base = dotOpEnc.getMMAv2kWidth();
 
           // Get maxPhase based on mfma output block dim
           // For now, the block dim is hard coded as 32
@@ -610,20 +596,36 @@ section 9.7.13.4.1 for more details.
     AttrBuilder<(ins "unsigned":$opIdx,
                      "Attribute":$parent,
                      "Type":$eltTy), [{
-      MmaEncodingAttr parentAttr = parent.dyn_cast<MmaEncodingAttr>();
-      if (!parentAttr || !parentAttr.isAmpere())
-        return $_get(context, opIdx, parent, 0);
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();
-      unsigned MMAv2kWidth = 32 / bitwidth;
-      return $_get(context, opIdx, parent, MMAv2kWidth);
-    }]>,
 
-    // Specially for MFMA(MI100/MI200)
-    AttrBuilder<(ins "unsigned":$opIdx,
-                     "Attribute":$parent), [{
-      assert(llvm::isa<MfmaEncodingAttr>(parent));
-      unsigned MMAv2kWidth = 0; // unused for MFMA ops
-      return $_get(context, opIdx, parent, MMAv2kWidth);
+      // ---- begin NV path ----
+      MmaEncodingAttr parentAttr = parent.dyn_cast<MmaEncodingAttr>();
+      if (parentAttr) {
+        if (!parentAttr.isAmpere())
+          return $_get(context, opIdx, parent, 0);
+        unsigned MMAv2kWidth = 32 / bitwidth;
+        return $_get(context, opIdx, parent, MMAv2kWidth);
+      }
+
+      // --- begin AMD (GFX908/GFX90A) path ----
+      MfmaEncodingAttr parentMfmaAttr = parent.dyn_cast<MfmaEncodingAttr>();
+      if (parentMfmaAttr) {
+        // Get k_base based on the element type
+        // For now, the k_base rules are as follows
+        // 1. All selected mfma instructions produce a single block
+        // 2. For f16 data type, 2 VGPRs are used for operand A --> k_base = 4
+        // 3. For non-f16 data types, 1 VGPR are used for operand A
+        //    k_base = 32 / elemTypeInBits
+        // 4. TODO: what about f64?
+        // TODO: For more general mfma instruction selection logic, it could
+        // be difficult to infer k_base based on eleTy only.
+        unsigned k_base = 32 / bitwidth;
+        if (eltTy.isF16())
+          k_base *= 2;
+        return $_get(context, opIdx, parent, k_base);
+      }
+
+      return $_get(context, opIdx, parent, 0);
     }]>
   ];
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -91,30 +91,35 @@ A_{3, 2}  A_{3, 3}  A_{3, 0}  A_{3, 1} ...   [phase 1] /
           perPhase = std::max<int>(perPhase, 1);
 
           // index of the inner dimension in `order`
+          // This is the nonKDim of the tensor
           unsigned inner = (opIdx == 0) ? 0 : 1;
-          // for now, disable swizzle when using transposed int8 tensor cores
-          if (eltTy.isInteger(8) && order[0] == inner)
+
+          // For now, disable swizzling when k is not the leading dim
+          if (order[0] == inner)
             return $_get(context, 1, 1, 1, order);
 
-          // --- handle A operand ---
-          if (opIdx == 0) { // compute swizzling for A operand
-              // This is just an example of swizzle pattern, not a production ready
-              unsigned vec = 8;
-              unsigned maxPhase = 2;
-              unsigned perPhase = 1;
-              return $_get(context, vec, perPhase, maxPhase, order);
-          }
+          // Get k_base based on the element type
+          // For now, the k_base rules are as follows
+          // 1. All selected mfma instructions produce a single block
+          // 2. For f16 data type, 2 VGPRs are used for operand A --> k_base = 4
+          // 3. For non-f16 data types, 1 VGPR are used for operand A
+          //    k_base = 32 / elemTypeInBits
+          // 4. TODO: what about f64?
+          // TODO: For more general mfma instruction selection logic, it could
+          // be difficult to infer k_base based on eleTy only.
+          // Then it's better to embed k_base into MfmaEncodingAttr
+          unsigned k_base;
+          if (eltTy.isF16())
+            k_base = 2 * 32 / eltTy.getIntOrFloatBitWidth();
+          else
+            k_base = 32 / eltTy.getIntOrFloatBitWidth();
 
-          // --- handle B operand ---
-          if (opIdx == 1) {
-              // This is an example of swizzle pattern, not a production ready
-              unsigned vec = 2;
-              unsigned maxPhase = 2;
-              unsigned perPhase = 1;
-              return $_get(context, vec, perPhase, maxPhase, order);
-          }
+          // Get maxPhase based on mfma output block dim
+          // For now, the block dim is hard coded as 32
+          // TODO: This should be the nonKDim from the MfmaEncodingAttr
+          unsigned maxPhase = 32 / perPhase;
 
-          llvm_unreachable("invalid operand index");
+          return $_get(context, k_base, perPhase, maxPhase, order);
         }
 #endif
         auto mmaEnc = dotOpEnc.getParent().dyn_cast<MmaEncodingAttr>();

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -176,10 +176,10 @@ public:
 
     auto newAType = RankedTensorType::get(
         oldAType.getShape(), oldAType.getElementType(),
-        triton::gpu::DotOperandEncodingAttr::get(ctx, 0, mfmaEnc));
+        triton::gpu::DotOperandEncodingAttr::get(ctx, 0, mfmaEnc, oldAType.getElementType()));
     auto newBType = RankedTensorType::get(
         oldBType.getShape(), oldBType.getElementType(),
-        triton::gpu::DotOperandEncodingAttr::get(ctx, 1, mfmaEnc));
+        triton::gpu::DotOperandEncodingAttr::get(ctx, 1, mfmaEnc, oldAType.getElementType()));
     a = rewriter.create<triton::gpu::ConvertLayoutOp>(a.getLoc(), newAType, a);
     b = rewriter.create<triton::gpu::ConvertLayoutOp>(b.getLoc(), newBType, b);
     auto newDot = rewriter.create<triton::DotOp>(


### PR DESCRIPTION
https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/4925

This PR selects the swizzling parameters (`vec`, `perPhase`, and `maxPhase`) according to the selected mfma instructions for tensors whose leading dim is `k`.
Note that `vec` is set as `k_base` which
- is the number of elements each thread needs to load from LDS for one mfma instruction
- is set based on element type when creating the `DotOperandEncodingAttr`

For now, each thread loads one element at a time. This will be fixed by the next PR, which will also refactor the code to remove redundant computations.

Another note, `test_gemm` is failing on `triton-mlir`. we'll need to fix the issues there before adding unit tests for swizzling.